### PR TITLE
Add linux support for `t`

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "-h" ]; then
   echo ""


### PR DESCRIPTION
I tried running this script on linux. It failed. I'm assuming it's because `t` isn't POSIX compliant, but I don't know enough about shell scripting to say this confidently.

I don't use macOS regularly, so I may be wrong. On macOS, `/bin/sh` is `bash`. But on linux `/bin/sh` is usually `dash`. `t` fails to run on `dash`. This can be observed by changing the shebang to call `dash` instead of `sh`. But since `t` was written to be called on `bash`, a simple fix is to just change the shebang so it works on linux.

I've tested these changes on an M1 mac. It should work on any machine that has `bash` installed. 

An even better fix is to fix this script so that it can run on `dash`. I can begin working on this.