### PR TITLE
fix: Allow session whos names are substings of other sessions

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -37,7 +37,7 @@ fi
 FOLDER=$(basename "$ZOXIDE_RESULT")
 SESSION_NAME=$(echo "$FOLDER" | tr ' ' '_' | tr '.' '_' | tr ':' '_')
 
-SESSION=$(tmux list-sessions -F '#S' | grep -F "^$SESSION_NAME$") # find existing session
+SESSION=$(tmux list-sessions -F '#S' | grep "^$SESSION_NAME$") # find existing session
 
 if [ "$TMUX" = "" ]; then # if not currently in tmux
     if [ "$SESSION" = "" ]; then # session does not exist

--- a/bin/t
+++ b/bin/t
@@ -35,7 +35,7 @@ if [ "$ZOXIDE_RESULT" = "" ]; then
 fi
 
 FOLDER=$(basename "$ZOXIDE_RESULT")
-SESSION_NAME=$(echo "$FOLDER" | tr ' ' '_' | tr '.' '_')
+SESSION_NAME=$(echo "$FOLDER" | tr ' ' '_' | tr '.' '_' | tr ':' '_')
 
 SESSION=$(tmux list-sessions | grep -F "$SESSION_NAME" | awk '{print $1}') # find existing session
 SESSION=${SESSION//:/} # grab session name

--- a/bin/t
+++ b/bin/t
@@ -37,8 +37,7 @@ fi
 FOLDER=$(basename "$ZOXIDE_RESULT")
 SESSION_NAME=$(echo "$FOLDER" | tr ' ' '_' | tr '.' '_' | tr ':' '_')
 
-SESSION=$(tmux list-sessions -F '#S' | grep -F "^$SESSION_NAME$" | awk '{print $1}') # find existing session
-SESSION=${SESSION//:/} # grab session name
+SESSION=$(tmux list-sessions -F '#S' | grep -F "^$SESSION_NAME$") # find existing session
 
 if [ "$TMUX" = "" ]; then # if not currently in tmux
     if [ "$SESSION" = "" ]; then # session does not exist

--- a/bin/t
+++ b/bin/t
@@ -37,7 +37,7 @@ fi
 FOLDER=$(basename "$ZOXIDE_RESULT")
 SESSION_NAME=$(echo "$FOLDER" | tr ' ' '_' | tr '.' '_' | tr ':' '_')
 
-SESSION=$(tmux list-sessions | grep -F "$SESSION_NAME" | awk '{print $1}') # find existing session
+SESSION=$(tmux list-sessions -F '#S' | grep -F "^$SESSION_NAME$" | awk '{print $1}') # find existing session
 SESSION=${SESSION//:/} # grab session name
 
 if [ "$TMUX" = "" ]; then # if not currently in tmux


### PR DESCRIPTION
Currently, there's an issue with sessions that share substrings in their names. For example; say you have the sessions `test` and `testing` in `foo/test` and `bar/testing` respectively, trying to jump to `test` would result in `tmux list-sessions | grep -F "$SESSION_NAME"` finding both sessions, which may fail or have undefined behavior.

This PR aims to fix this by using tmux's `-F` flag to only list sessions by their name and making sure grep finds the exact session name using regex `^`(start of string) and `$`(regex end of string).