### PR TITLE
feat: list tmux sessions and zoxide

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -21,10 +21,15 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
 	printf "\n"
 elif [ $# -eq 0 ]; then
 	FZF_BORDER_LABEL=" t - smart tmux session manager "
+	HEADER="ctrl-a all / ctrl-s sessions / ctrl-x zoxide"
+	PROMPT="All> "
+	ALL_BINDING="ctrl-a:change-prompt(All> )+reload(tmux list-sessions -F '#S' && zoxide query -l)"
+	SESSION_BINDING="ctrl-s:change-prompt(Sessions> )+reload(tmux list-sessions -F '#S')"
+	ZOXIDE_BINDING="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l)"
 	if [ "$TMUX" = "" ]; then
-		ZOXIDE_RESULT=$(zoxide query -l | fzf --reverse --border-label "$FZF_BORDER_LABEL")
+		ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
 	else
-		ZOXIDE_RESULT=$(zoxide query -l | fzf-tmux -p --reverse --border-label "$FZF_BORDER_LABEL")
+		ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf-tmux -p --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
 	fi
 else
 	ZOXIDE_RESULT=$(zoxide query "$1")


### PR DESCRIPTION
New feature! Current tmux sessions are now listed at the top of the fzf list. I've found that I often want a session that's already open so it's now first in the fzf list for quick access and matching.

I've also added keyboard shortcuts to allow you to toggle between tmux sessions ctrl-s, zoxide entries ctrl-x (ctrl-z is a reserved keybinding), and all results ctrl-a for more fine-grained control.

<img width="795" alt="Screenshot 2023-02-23 at 10 53 04 AM" src="https://user-images.githubusercontent.com/2036594/220975905-c9cd3b3d-ef99-4a73-ad90-bfe14478178b.png">
