### PR TITLE
feat: add option to search for paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ tmux is a powerful tool, but dealing with sessions can be painful. This script m
 - [tmux](https://github.com/tmux/tmux)
 - [zoxide](https://github.com/ajeetdsouza/zoxide)
 - [fzf](https://github.com/junegunn/fzf)
+- [fd](https://github.com/sharkdp/fd) (optional)
 
 ## How to install
 
@@ -89,6 +90,7 @@ You can learn more about how the script works in [this video](https://www.youtub
 - [x] Add docs
 - [x] Add help flag with basic documentation (`t -h`)
 - [x] List tmux sessions
+- [x] Add option to start a session for any directory under the home dir
 - [ ] Publish YouTube video on how to install it
 - [ ] Save zoxide entries selected from t script (with sqlite?)
 - [ ] Allow user to overwrite options (ex: `set -g @t-smart-tmux-session-manager-options "-p --reverse`)

--- a/bin/t
+++ b/bin/t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # cSpell:words elif
 
 if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
@@ -21,19 +21,28 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
 	printf "\n"
 elif [ $# -eq 0 ]; then
 	FZF_BORDER_LABEL=" t - smart tmux session manager "
-	HEADER="ctrl-a all / ctrl-s sessions / ctrl-x zoxide"
+	HEADER="ctrl-a: all / ctrl-s: sessions / ctrl-x: zoxide / ctrl-p: path"
 	PROMPT="All> "
 	ALL_BINDING="ctrl-a:change-prompt(All> )+reload(tmux list-sessions -F '#S' && zoxide query -l)"
 	SESSION_BINDING="ctrl-s:change-prompt(Sessions> )+reload(tmux list-sessions -F '#S')"
 	ZOXIDE_BINDING="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l)"
+
+  # Use `fd` to generate a list of sub-directories under `$HOME`
+  PATH_BINDING="ctrl-p:change-prompt(Path> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
+
+  # If `fd` isn't installed, use `find` to generate a list of sub-directories under the current directory
+  if ! command -v fd &> /dev/null; then
+    PATH_BINDING="ctrl-p:change-prompt(Path> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
+  fi
+
 	if [ "$TMUX" = "" ]; then       # if not currently in tmux
 		if tmux info &>/dev/null; then # if tmux is running
-			ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
+			ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --bind "$PATH_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
 		else # tmux is not running
-			ZOXIDE_RESULT=$(zoxide query -l | fzf --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
+			ZOXIDE_RESULT=$(zoxide query -l | fzf --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --bind "$PATH_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
 		fi
 	else # currently in tmux
-		ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf-tmux -p --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
+		ZOXIDE_RESULT=$( (tmux list-sessions -F '#S' && zoxide query -l) | fzf-tmux -p --reverse --prompt "$PROMPT" --bind "$ALL_BINDING" --bind "$SESSION_BINDING" --bind "$ZOXIDE_BINDING" --bind "$PATH_BINDING" --border-label "$FZF_BORDER_LABEL" --header "$HEADER")
 	fi
 else
 	ZOXIDE_RESULT=$(zoxide query "$1")


### PR DESCRIPTION
This implements #8.

Since you might sometimes want to start a session in a directory that zoxide isn't familiar with, this pull request adds a `path` binding, bound to `ctrl-p`, which replaces the fzf source to a list of all directories under the user's home dir. Since this can be a very large list, it isn't included in sources of the default `all` prompt, and only replaces the sources when picked. Basically, in the odd case you want to start a session in a path that isn't in zoxide for whatever reason, you can opt-in to querying your file system, but it doesn't pollute the default results.

By default, the `path` binding generates the fzf source using `fd` which is a fast Rust-based alternative to `find`, which by default respects `.gitignore`. In cases where `fd` cannot be detected, the `path` binding will fallback to using `find` to generate the source list.