### PR TITLE
feat: alias $HOME as '~' if safe to do so

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -21,14 +21,21 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 	exit 0
 fi
 
+HOME_REPLACER=""                                          # default to a noop
+echo "$HOME" | grep -E "^[a-zA-Z0-9\-_/.@]+$" &>/dev/null # chars safe to use in sed
+HOME_SED_SAFE=$?
+if [ $HOME_SED_SAFE -eq 0 ]; then # $HOME should be safe to use in sed
+	HOME_REPLACER="s|^$HOME/|~/|"
+fi
+
 tmux ls &>/dev/null
 TMUX_STATUS=$?
 BORDER_LABEL=" t - smart tmux session manager "
 HEADER="ctrl-a: all / ctrl-s: sessions / ctrl-x: zoxide / ctrl-p: path"
 SESSION_BIND="ctrl-s:change-prompt(Sessions> )+reload(tmux list-sessions -F '#S')"
-ZOXIDE_BIND="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l)"
+ZOXIDE_BIND="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
 PROMPT="All> "
-ALL_BIND="ctrl-a:change-prompt($PROMPT)+reload(tmux list-sessions -F '#S' && zoxide query -l)"
+ALL_BIND="ctrl-a:change-prompt($PROMPT)+reload(tmux list-sessions -F '#S' && (zoxide query -l | sed -e \"$HOME_REPLACER\"))"
 
 if fd --version &>/dev/null; then # fd is installed
 	PATH_BIND="ctrl-p:change-prompt(Path> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
@@ -40,7 +47,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 	if [ "$TMUX" = "" ]; then        # not in tmux
 		if [ $TMUX_STATUS -eq 0 ]; then # tmux is running
 			RESULT=$(
-				(tmux list-sessions -F '#S' && zoxide query -l) | fzf \
+				(tmux list-sessions -F '#S' && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf \
 					--reverse \
 					--header "$HEADER" \
 					--prompt "$PROMPT" \
@@ -49,14 +56,14 @@ if [ $# -eq 0 ]; then             # no argument provided
 			)
 		else # tmux is not running
 			RESULT=$(
-				zoxide query -l | fzf \
+				(zoxide query -l | sed -e "$HOME_REPLACER") | fzf \
 					--reverse \
 					--prompt "$PROMPT"
 			)
 		fi
 	else # in tmux
 		RESULT=$(
-			(tmux list-sessions -F '#S' && zoxide query -l) | fzf-tmux -p 70% \
+			(tmux list-sessions -F '#S' && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux -p 70% \
 				--reverse \
 				--header "$HEADER" \
 				--prompt "$PROMPT" \
@@ -83,6 +90,10 @@ fi
 
 if [ "$RESULT" = "" ]; then # no result
 	exit 0                     # exit silently
+fi
+
+if [ $HOME_SED_SAFE -eq 0 ]; then
+	RESULT=$(echo "$RESULT" | sed -e "s|^~/|$HOME/|") # get real home path back
 fi
 
 zoxide add "$RESULT" &>/dev/null # add to zoxide database


### PR DESCRIPTION
Sorry, was a bit quick with my last PR and didn't test it enough 😓
Fixes #10

This time it reverses the alias back to `$HOME` before being used.

I also realized that `sed` treats some chars as special chars so now it only aliases if safe to use `$HOME` unescaped in `sed`.
The current allowed chars are pretty strict and could probably be expanded.

## Tested shells/os
- [X] zsh GNU/Linux
- [X] bash GNU/Linux
- [X] zsh macOS
- [X] bash macOS