### PR TITLE
feat: switch ctrl-p to ctrl-d

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run interactive mode
     ctrl-a list tmux sessions and zoxide results (default)
     ctrl-s list only tmux sessions
     ctrl-z list only zoxide results
-    ctrl-p list fd results (or find if fd isn't installed)
+    ctrl-d list directories
 
 Go to session (matches tmux session, zoxide result, or path)
     t {name}
@@ -105,7 +105,7 @@ If you are not in tmux, you can simply run `t` to start the interactive script, 
 - `ctrl-a` list tmux sessions and zoxide results (default)
 - `ctrl-s` list only tmux sessions
 - `ctrl-z` list only zoxide results
-- `ctrl-p` list fd results (or find if fd isn't installed)
+- `ctrl-d` list directories (or find if fd isn't installed)
 
 You can learn more about how the script works in [this video](https://www.youtube.com/watch?v=l_TTxc0AcCw).
 

--- a/bin/t
+++ b/bin/t
@@ -8,7 +8,7 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 	printf "\033[32m  Run interactive mode\n"
 	printf "\033[34m      t\n"
 	printf "\n"
-	printf "\033[32m  Go to session (matches tmux session, zoxide result, or path)\n"
+	printf "\033[32m  Go to session (matches tmux session, zoxide result, or directory)\n"
 	printf "\033[34m      t {name}\n"
 	printf "\n"
 	printf "\033[32m  Open popup (while in tmux)\n"
@@ -24,16 +24,16 @@ fi
 tmux ls &>/dev/null
 TMUX_STATUS=$?
 BORDER_LABEL=" t - smart tmux session manager "
-HEADER="ctrl-a: all / ctrl-s: sessions / ctrl-x: zoxide / ctrl-p: path"
+HEADER="ctrl-a: all / ctrl-s: sessions / ctrl-x: zoxide / ctrl-d: directory"
 SESSION_BIND="ctrl-s:change-prompt(Sessions> )+reload(tmux list-sessions -F '#S')"
 ZOXIDE_BIND="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l)"
 PROMPT="All> "
 ALL_BIND="ctrl-a:change-prompt($PROMPT)+reload(tmux list-sessions -F '#S' && zoxide query -l)"
 
 if fd --version &>/dev/null; then # fd is installed
-	PATH_BIND="ctrl-p:change-prompt(Path> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
+	DIR_BIND="ctrl-d:change-prompt(Directory> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
 else # fd is not installed
-	PATH_BIND="ctrl-p:change-prompt(Path> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
+	DIR_BIND="ctrl-d:change-prompt(Directory> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
 fi
 
 if [ $# -eq 0 ]; then             # no argument provided
@@ -45,7 +45,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 					--header "$HEADER" \
 					--prompt "$PROMPT" \
 					--border-label "$BORDER_LABEL" \
-					--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$PATH_BIND"
+					--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$DIR_BIND"
 			)
 		else # tmux is not running
 			RESULT=$(
@@ -61,7 +61,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 				--header "$HEADER" \
 				--prompt "$PROMPT" \
 				--border-label "$BORDER_LABEL" \
-				--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$PATH_BIND"
+				--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$DIR_BIND"
 		)
 	fi
 else # argument provided


### PR DESCRIPTION
Closes #8 

Switching `ctrl-p` to `ctrl-d` (directory) since `ctrl-p` is a reasonable default for going to the previous result in fzf.