### PR TITLE
Custom Prompt, FZF Updates, Tmux Recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ fish_add_path $HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin
 
 </details>
 
+### 3. Customize Prompt (optional)
+
+If your terminal supports [Nerd Font symbols](https://www.nerdfonts.com/), you can customize your prompt.
+
+```
+set -g @t-fzf-prompt '  '
+```
+
+Or you can replace the prompt with anything you'd like.
+
+### 4. Recommended tmux settings
+
+I recommend you add these settings to your `tmux.conf` to have a better experience with this script.
+
+```
+bind-key x kill-pane # skip "kill-pane 1? (y/n)" prompt
+set -g detach-on-destroy off  # don't exit from tmux when closing a session
+```
+
 ## How to use
 
 ```sh
@@ -102,7 +121,6 @@ If you are not in tmux, you can simply run `t` to start the interactive script, 
 
 ### Key Bindings
 
-- `ctrl-a` list tmux sessions and zoxide results (default)
 - `ctrl-s` list only tmux sessions
 - `ctrl-z` list only zoxide results
 - `ctrl-d` list directories (or find if fd isn't installed)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,16 @@ fish_add_path $HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin
 
 </details>
 
-### 3. Customize Prompt (optional)
+### 3. Recommended tmux settings
+
+I recommend you add these settings to your `tmux.conf` to have a better experience with this script.
+
+```
+bind-key x kill-pane # skip "kill-pane 1? (y/n)" prompt
+set -g detach-on-destroy off  # don't exit from tmux when closing a session
+```
+
+### 4. Customize Prompt (optional)
 
 If your terminal supports [Nerd Font symbols](https://www.nerdfonts.com/), you can customize your prompt.
 
@@ -84,15 +93,6 @@ set -g @t-fzf-prompt '  '
 ```
 
 Or you can replace the prompt with anything you'd like.
-
-### 4. Recommended tmux settings
-
-I recommend you add these settings to your `tmux.conf` to have a better experience with this script.
-
-```
-bind-key x kill-pane # skip "kill-pane 1? (y/n)" prompt
-set -g detach-on-destroy off  # don't exit from tmux when closing a session
-```
 
 ## How to use
 

--- a/bin/t
+++ b/bin/t
@@ -21,6 +21,18 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 	exit 0
 fi
 
+tmux ls &>/dev/null
+TMUX_STATUS=$?
+
+get_fzf_prompt() {
+	local fzf_prompt
+	local fzf_default_prompt='>  '
+	if [ $TMUX_STATUS -eq 0 ]; then # tmux is running
+		fzf_prompt="$(tmux show -gqv '@t-fzf-prompt')"
+	fi
+	[ -n "$fzf_prompt" ] && echo "$fzf_prompt" || echo "$fzf_default_prompt"
+}
+
 HOME_REPLACER=""                                          # default to a noop
 echo "$HOME" | grep -E "^[a-zA-Z0-9\-_/.@]+$" &>/dev/null # chars safe to use in sed
 HOME_SED_SAFE=$?
@@ -28,19 +40,16 @@ if [ $HOME_SED_SAFE -eq 0 ]; then # $HOME should be safe to use in sed
 	HOME_REPLACER="s|^$HOME/|~/|"
 fi
 
-tmux ls &>/dev/null
-TMUX_STATUS=$?
 BORDER_LABEL=" t - smart tmux session manager "
-HEADER="ctrl-a: all / ctrl-s: sessions / ctrl-x: zoxide / ctrl-d: directory"
-SESSION_BIND="ctrl-s:change-prompt(Sessions> )+reload(tmux list-sessions -F '#S')"
-ZOXIDE_BIND="ctrl-x:change-prompt(Zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
-PROMPT="All> "
-ALL_BIND="ctrl-a:change-prompt($PROMPT)+reload(tmux list-sessions -F '#S' && (zoxide query -l | sed -e \"$HOME_REPLACER\"))"
+HEADER=" ctrl-s: sessions / ctrl-x: zoxide / ctrl-d: directory"
+PROMPT=$(get_fzf_prompt)
+SESSION_BIND="ctrl-s:change-prompt(sessions> )+reload(tmux list-sessions -F '#S')"
+ZOXIDE_BIND="ctrl-x:change-prompt(zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
 
 if fd --version &>/dev/null; then # fd is installed
-	DIR_BIND="ctrl-d:change-prompt(Directory> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
+	DIR_BIND="ctrl-d:change-prompt(directory> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
 else # fd is not installed
-	DIR_BIND="ctrl-d:change-prompt(Directory> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
+	DIR_BIND="ctrl-d:change-prompt(directory> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
 fi
 
 if [ $# -eq 0 ]; then             # no argument provided
@@ -48,27 +57,32 @@ if [ $# -eq 0 ]; then             # no argument provided
 		if [ $TMUX_STATUS -eq 0 ]; then # tmux is running
 			RESULT=$(
 				(tmux list-sessions -F '#S' && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf \
-					--reverse \
-					--header "$HEADER" \
-					--prompt "$PROMPT" \
+					--bind "$DIR_BIND" \
+					--bind "$SESSION_BIND" \
+					--bind "$ZOXIDE_BIND" \
 					--border-label "$BORDER_LABEL" \
-					--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$DIR_BIND"
+					--header "$HEADER" \
+					--prompt "$PROMPT"
 			)
 		else # tmux is not running
 			RESULT=$(
 				(zoxide query -l | sed -e "$HOME_REPLACER") | fzf \
-					--reverse \
+					--bind "$DIR_BIND" \
+					--border-label "$BORDER_LABEL" \
+					--header " ctrl-d: directory" \
 					--prompt "$PROMPT"
 			)
 		fi
 	else # in tmux
 		RESULT=$(
-			(tmux list-sessions -F '#S' && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux -p 70% \
-				--reverse \
+			(tmux list-sessions -F '#S' && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux \
+				--bind "$DIR_BIND" \
+				--bind "$SESSION_BIND" \
+				--bind "$ZOXIDE_BIND" \
+				--border-label "$BORDER_LABEL" \
 				--header "$HEADER" \
 				--prompt "$PROMPT" \
-				--border-label "$BORDER_LABEL" \
-				--bind "$ALL_BIND" --bind "$SESSION_BIND" --bind "$ZOXIDE_BIND" --bind "$DIR_BIND"
+				-p 60%,50%
 		)
 	fi
 else # argument provided

--- a/t-smart-tmux-session-manager.tmux
+++ b/t-smart-tmux-session-manager.tmux
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 tmux bind-key T run-shell "$CURRENT_DIR/bin/t"


### PR DESCRIPTION
- Add ability to customize the fzf prompt
- Drop the fzf `--reverse`
- Drop the "all" keybinding as it wasn't working properly
- Add docs for how to customize the prompt
- Add docs for recommended tmux settings
- Minor formatting updates
- Break fzf commands into separate lines and sort flags alphabetically

Here's a preview of the custom prompt:
<img width="1496" alt="Screenshot 2023-03-22 at 12 09 58 PM" src="https://user-images.githubusercontent.com/2036594/226990605-3e3f4d6f-671b-4fa3-b7e3-77913a184386.png">


