### PR TITLE
feat: sort zoxide by score

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -68,6 +68,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 					--bind "$ZOXIDE_BIND" \
 					--border-label "$BORDER_LABEL" \
 					--header "$HEADER" \
+					--no-sort \
 					--prompt "$PROMPT"
 			)
 		else # tmux is not running
@@ -76,6 +77,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 					--bind "$DIR_BIND" \
 					--border-label "$BORDER_LABEL" \
 					--header " ctrl-d: directory" \
+					--no-sort \
 					--prompt "$PROMPT"
 			)
 		fi
@@ -87,6 +89,7 @@ if [ $# -eq 0 ]; then             # no argument provided
 				--bind "$ZOXIDE_BIND" \
 				--border-label "$BORDER_LABEL" \
 				--header "$HEADER" \
+				--no-sort \
 				--prompt "$PROMPT" \
 				-p 60%,50%
 		)


### PR DESCRIPTION
Closes #25 

It is slightly counter-intuitive, but according to the zoxide author, the zoxide query list command already sorts results by the score so I have to add `--no-sort` to fzf to prevent fzf from sorting alphabetically.