### PR TITLE
feat: improve find command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # t - the smart tmux session manager
 
-tmux is a powerful tool, but dealing with sessions can be painful. This script makes it easy to create and switch tmux sessions:
+tmux is a powerful tool, but dealing with sessions can be painful. This scriptmakes it easy to create and switch tmux sessions:
 
 ## Prerequisites
 
@@ -14,7 +14,6 @@ tmux is a powerful tool, but dealing with sessions can be painful. This script m
 - [tpm](https://github.com/tmux-plugins/tpm)
 - [zoxide](https://github.com/ajeetdsouza/zoxide)
 - [fzf](https://github.com/junegunn/fzf) (>=0.35.0)
-- [fd](https://github.com/sharkdp/fd) (optional)
 
 ## How to install
 
@@ -104,7 +103,6 @@ Or you can replace the prompt with anything you'd like.
       t
         ctrl-s list only tmux sessions
         ctrl-x list only zoxide results
-        ctrl-d list directories
 
   Go to session (matches tmux session, zoxide result, or directory)
       t {name}
@@ -113,7 +111,6 @@ Or you can replace the prompt with anything you'd like.
       <prefix>+T
         ctrl-s list only tmux sessions
         ctrl-x list only zoxide results
-        ctrl-d list directories
 
   Show help
       t -h
@@ -128,17 +125,41 @@ If you are not in tmux, you can simply run `t` to start the interactive script, 
 
 - `ctrl-s` list only tmux sessions
 - `ctrl-x` list only zoxide results
-- `ctrl-d` list directories (or find if fd isn't installed)
+- `ctrl-f` find by directory
 
-## How to add a custom keybinding
+## How to customize
 
-In order to add your own custom key binding to trigger the `t` script, add the following to your `tmux.conf`:
+### Custom fzf-tmux keybinding
+
+By default, the `t` popup is bound to `<prefix>T`. In order to overwrite your own custom key binding, add setting the `@t-bind` varaible to your `tmux.conf`:
 
 ```sh
-set -g @t-bind "J"
+set -g @t-bind "K"
 ```
 
-You can unbind the default by entering an unmappable string (e.g. `none`)
+You can unbind the default by using `none`.
+
+```sh
+set -g @t-bind "none" # unbind default
+```
+
+### Custom find command
+
+By default, the find key binding (`^f`) will run a simple `find` command to search for directories in and around your home directory.
+
+```sh
+find ~ -maxdepth 3 -type d
+```
+
+You can customize this command by setting `@t-find-binding` variable to your `tmux.conf`:
+
+In this example, I'm setting the prompt with a custom [Nerd Font icon](https://www.nerdfonts.com/) and using [fd](https://github.com/sharkdp/fd) to search directories (including hidden ones) up to two levels deep from my home directory.
+
+```sh
+set -g @t-find-binding 'ctrl-f:change-prompt(  )+reload(fd -H -d 2 -t d . ~)'
+```
+
+Run `man fzf` to learn more about how to customize key bindings with fzf.
 
 ## Background
 
@@ -156,7 +177,7 @@ Add the following line to your `alacritty.yml`
 
 ```yml
 key_bindings:
-  - { key: J, mods: Command, chars: "\x02\x54" } # open t - tmux smart session manager
+  - { key: K, mods: Command, chars: "\x02\x54" } # open t - tmux smart session manager
 ```
 
 </details>
@@ -167,7 +188,7 @@ key_bindings:
 Add the following line to your `kitty.conf`
 
 ```sh
-map cmd+j send_text all \x02\x54
+map cmd+k send_text all \x02\x54
 ```
 
 </details>

--- a/bin/t
+++ b/bin/t
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 
-if tmux list-sessions &>/dev/null; then # tmux server is running
-	if [ "$TMUX" ]; then                   # inside tmux
+# determine if the tmux server is running
+if tmux list-sessions &>/dev/null; then
+	TMUX_RUNNING=0
+else
+	TMUX_RUNNING=1
+fi
+
+# determine the user's current position relative tmux:
+# serverless - there is no running tmux server
+# attached   - the user is currently attached to the running tmux server
+# detached   - the user is currently not attached to the running tmux server
+T_RUNTYPE="serverless"
+if [ "$TMUX_RUNNING" -eq 0 ]; then
+	if [ "$TMUX" ]; then # inside tmux
 		T_RUNTYPE="attached"
 	else # outside tmux
 		T_RUNTYPE="detached"
 	fi
-else # tmux server is not running
-	T_RUNTYPE="serverless"
 fi
 
-if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
+# display help text with an argument
+if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
 	printf "\n"
 	printf "\033[1m  t - the smart tmux session manager\033[0m\n"
 	printf "\033[37m  https://github.com/joshmedeski/t-smart-tmux-session-manager\n"
@@ -19,13 +30,14 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 	printf "\033[34m      t\n"
 	printf "\033[34m        ctrl-s list only tmux sessions\n"
 	printf "\033[34m        ctrl-x list only zoxide results\n"
-	printf "\033[34m        ctrl-d list directories\n"
+	printf "\033[34m        ctrl-f list results from the find command\n"
 	printf "\n"
 	printf "\033[32m  Go to session (matches tmux session, zoxide result, or directory)\n"
 	printf "\033[34m      t {name}\n"
 	printf "\n"
-	if [ "$T_RUNTYPE" == "attached" ]; then
-		printf "\033[32m  Open popup (while in tmux)\n"
+	printf "\033[32m  Open popup (while in tmux)\n"
+
+	if [ "$TMUX_RUNNING" -eq 0 ]; then
 		T_BIND=$(tmux show-option -gvq "@t-bind")
 		if [ "$T_BIND" = "" ]; then
 			T_BIND="T"
@@ -33,8 +45,11 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 		printf "\033[34m      <prefix>+%s\n" "$T_BIND"
 		printf "\033[34m        ctrl-s list only tmux sessions\n"
 		printf "\033[34m        ctrl-x list only zoxide results\n"
-		printf "\033[34m        ctrl-d list directories\n"
+		printf "\033[34m        ctrl-f list results from the find command\n"
+	else
+		printf "\033[34m      start tmux server to see bindings\n" "$T_BIND"
 	fi
+
 	printf "\n"
 	printf "\033[32m  Show help\n"
 	printf "\033[34m      t -h\n"
@@ -43,15 +58,6 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then # help argument
 	exit 0
 fi
 
-get_fzf_prompt() {
-	local fzf_prompt
-	local fzf_default_prompt='>  '
-	if [ "$T_RUNTYPE" != "serverless" ]; then
-		fzf_prompt="$(tmux show -gqv '@t-fzf-prompt')"
-	fi
-	[ -n "$fzf_prompt" ] && echo "$fzf_prompt" || echo "$fzf_default_prompt"
-}
-
 HOME_REPLACER=""                                          # default to a noop
 echo "$HOME" | grep -E "^[a-zA-Z0-9\-_/.@]+$" &>/dev/null # chars safe to use in sed
 HOME_SED_SAFE=$?
@@ -59,17 +65,30 @@ if [ $HOME_SED_SAFE -eq 0 ]; then # $HOME should be safe to use in sed
 	HOME_REPLACER="s|^$HOME/|~/|"
 fi
 
-BORDER_LABEL=" t - smart tmux session manager "
-HEADER=" ctrl-s: sessions / ctrl-x: zoxide / ctrl-d: directory"
+get_fzf_prompt() {
+	local fzf_prompt
+	local fzf_default_prompt='>  '
+	if [ "$TMUX_RUNNING" -eq 0 ]; then
+		fzf_prompt="$(tmux show -gqv '@t-fzf-prompt')"
+	fi
+	[ -n "$fzf_prompt" ] && echo "$fzf_prompt" || echo "$fzf_default_prompt"
+}
 PROMPT=$(get_fzf_prompt)
+
+get_fzf_find_binding() {
+	local fzf_find_binding
+	local fzf_find_binding_default='ctrl-f:change-prompt(find> )+reload(find ~ -maxdepth 3 -type d)'
+	if [ "$TMUX_RUNNING" -eq 0 ]; then
+		fzf_find_binding="$(tmux show -gqv '@t-fzf-find-binding')"
+	fi
+	[ -n "$fzf_find_binding" ] && echo "$fzf_find_binding" || echo "$fzf_find_binding_default"
+}
+FIND_BIND=$(get_fzf_find_binding)
+
+BORDER_LABEL=" t - smart tmux session manager "
+HEADER=" ^s sessions ^x zoxide ^f find"
 SESSION_BIND="ctrl-s:change-prompt(sessions> )+reload(tmux list-sessions -F '#S')"
 ZOXIDE_BIND="ctrl-x:change-prompt(zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
-
-if fd --version &>/dev/null; then # fd is installed
-	DIR_BIND="ctrl-d:change-prompt(directory> )+reload(cd $HOME && echo $HOME; fd --type d --hidden --absolute-path --color never --exclude .git --exclude node_modules)"
-else # fd is not installed
-	DIR_BIND="ctrl-d:change-prompt(directory> )+reload(cd $HOME && find ~+ -type d -name node_modules -prune -o -name .git -prune -o -type d -print)"
-fi
 
 get_sessions_by_mru() {
 	tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort --numeric-sort --reverse | awk '{print $2}'
@@ -95,7 +114,7 @@ else # argument not provided
 	attached)
 		RESULT=$(
 			(get_sessions_by_mru && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux \
-				--bind "$DIR_BIND" \
+				--bind "$FIND_BIND" \
 				--bind "$SESSION_BIND" \
 				--bind "$ZOXIDE_BIND" \
 				--border-label "$BORDER_LABEL" \
@@ -108,7 +127,7 @@ else # argument not provided
 	detached)
 		RESULT=$(
 			(get_sessions_by_mru && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf \
-				--bind "$DIR_BIND" \
+				--bind "$FIND_BIND" \
 				--bind "$SESSION_BIND" \
 				--bind "$ZOXIDE_BIND" \
 				--border-label "$BORDER_LABEL" \
@@ -120,9 +139,9 @@ else # argument not provided
 	serverless)
 		RESULT=$(
 			(zoxide query -l | sed -e "$HOME_REPLACER") | fzf \
-				--bind "$DIR_BIND" \
+				--bind "$FIND_BIND" \
 				--border-label "$BORDER_LABEL" \
-				--header " ctrl-d: directory" \
+				--header " ^f find" \
 				--no-sort \
 				--prompt "$PROMPT"
 		)

--- a/cspell.json
+++ b/cspell.json
@@ -1,8 +1,6 @@
 {
-  "version": "0.2",
-  "words": [
-    "zoxide"
-  ],
+  "language": "en",
+  "words": ["zoxide", "maxdepth", "esac", "RUNTYPE", "joshmedeski"],
   "flagWords": [],
-  "language": "en"
+  "version": "0.2"
 }


### PR DESCRIPTION
Closes #38 

- Drop `fd` dependency
- Remap ^d directories fzf key binding to ^f for "find" command
- Allow user to set their own fzf-find-binding via tmux
- Change default find command to simple directory lookup from home with maxdepth
- Update docs and help text to reflect changes
- Provide example of custom find key binding