### PR TITLE
feat: allow FZF_TMUX_OPTS overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ export FZF_TMUX_OPTS="-p 55%,60%"
 set -Ux FZF_TMUX_OPTS "-p 55%,60%"
 ```
 
+Run `man fzf-tmux` to learn more about the available options.
+
 ## Background
 
 Interested in learning more about how this script came to be? Check out [Smart tmux sessions with zoxide and fzf](https://www.joshmedeski.com/posts/smart-tmux-sessions-with-zoxide-and-fzf/).

--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ set -g @t-fzf-find-binding 'ctrl-f:change-prompt(  )+reload(fd -H -d 2 -t d .
 
 Run `man fzf` to learn more about how to customize key bindings with fzf.
 
+### FZF_TMUX_OPTS
+
+If you want to overwrite the fzf-tmux options, you can set the `FZF_TMUX_OPTS` variable in your shell environment.
+
+```bash
+# ~/.bashrc or ~/.zshrc
+export FZF_TMUX_OPTS="-p 55%,60%"
+```
+
+```fish
+# ~/.config/fish/config.fish
+set -Ux FZF_TMUX_OPTS "-p 55%,60%"
+```
+
 ## Background
 
 Interested in learning more about how this script came to be? Check out [Smart tmux sessions with zoxide and fzf](https://www.joshmedeski.com/posts/smart-tmux-sessions-with-zoxide-and-fzf/).

--- a/bin/t
+++ b/bin/t
@@ -119,7 +119,6 @@ else # argument not provided
 
 		RESULT=$(
 			(get_sessions_by_mru && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux \
-				$FZF_TMUX_OPTS \
 				--bind "$FIND_BIND" \
 				--bind "$SESSION_BIND" \
 				--bind "$TAB_BIND" \
@@ -127,7 +126,8 @@ else # argument not provided
 				--border-label "$BORDER_LABEL" \
 				--header "$HEADER" \
 				--no-sort \
-				--prompt "$PROMPT"
+				--prompt "$PROMPT" \
+				$FZF_TMUX_OPTS
 		)
 		;;
 	detached)

--- a/bin/t
+++ b/bin/t
@@ -113,8 +113,13 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
+		if [[ ! -v $FZF_TMUX_OPTS ]]; then
+			FZF_TMUX_OPTS="-p 53%,58%"
+		fi
+
 		RESULT=$(
 			(get_sessions_by_mru && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux \
+				$FZF_TMUX_OPTS \
 				--bind "$FIND_BIND" \
 				--bind "$SESSION_BIND" \
 				--bind "$TAB_BIND" \
@@ -122,8 +127,7 @@ else # argument not provided
 				--border-label "$BORDER_LABEL" \
 				--header "$HEADER" \
 				--no-sort \
-				--prompt "$PROMPT" \
-				-p 60%,50%
+				--prompt "$PROMPT"
 		)
 		;;
 	detached)


### PR DESCRIPTION
Closes #44 

Ability to use the user specifed `FZF_TMUX_OPTS` to overwrite the `fzf-tmux` behavior.