### PR TITLE
Parent dir session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,43 @@ If you are not in tmux, you can simply run `t` to start the interactive script, 
 
 ## How to customize
 
+### Include parent dir in session name
+
+You may prefer your session names having a prefix of the parent directory. This can help with naming conflicts if you have multiple directories with the same name on your machine.
+
+<details>
+<summary>bash</summary>
+
+Add the following line to `~/.bashrc`
+
+```sh
+export T_SESSION_NAME_INCLUDE_PARENT="true"
+```
+
+</details>
+
+<details>
+<summary>zsh</summary>
+
+Add the following line to `~/.zshrc`
+
+```sh
+export T_SESSION_NAME_INCLUDE_PARENT="true"
+```
+
+</details>
+
+<details>
+<summary>fish</summary>
+
+Add the following line to `~/.config/fish/conf.d/t.fish`
+
+```fish
+set -Ux T_SESSION_NAME_INCLUDE_PARENT true
+```
+
+</details>
+
 ### Custom fzf-tmux keybinding
 
 By default, the `t` popup is bound to `<prefix>T`. In order to overwrite your own custom key binding, add setting the `@t-bind` varaible to your `tmux.conf`:

--- a/bin/t
+++ b/bin/t
@@ -166,8 +166,12 @@ if [ $HOME_SED_SAFE -eq 0 ]; then
 fi
 
 zoxide add "$RESULT" &>/dev/null # add to zoxide database
-FOLDER=$(basename "$RESULT")
-SESSION_NAME=$(echo "$FOLDER" | tr ' .:' '_')
+
+if [[ $T_SESSION_NAME_INCLUDE_PARENT == 'true' ]]; then
+	SESSION_NAME=$(echo $RESULT | tr ' .:' '_' | awk -F "/" '{print $(NF-1)"/"$NF}')
+else
+	SESSION_NAME=$(basename "$RESULT" | tr ' .:' '_')
+fi
 
 if [ "$T_RUNTYPE" != "serverless" ]; then
 	SESSION=$(tmux list-sessions -F '#S' | grep "^$SESSION_NAME$") # find existing session

--- a/bin/t
+++ b/bin/t
@@ -168,7 +168,7 @@ fi
 zoxide add "$RESULT" &>/dev/null # add to zoxide database
 
 if [[ $T_SESSION_NAME_INCLUDE_PARENT == 'true' ]]; then
-	SESSION_NAME=$(echo $RESULT | tr ' .:' '_' | awk -F "/" '{print $(NF-1)"/"$NF}')
+	SESSION_NAME=$(echo "$RESULT" | tr ' .:' '_' | awk -F "/" '{print $(NF-1)"/"$NF}')
 else
 	SESSION_NAME=$(basename "$RESULT" | tr ' .:' '_')
 fi


### PR DESCRIPTION
Closes #50 

Adds the ability to set `T_SESSION_NAME_INCLUDE_PARENT` to your shell and enable session names to include their parent directory.

## How to test

You can test this by updating your tpm entry to:

```
set -g @plugin 'joshmedeski/t-smart-tmux-session-manager#parent-dir-session-name'
```

The reinstall the tpm package.

Next, you'll need to add the `T_SESSION_NAME_INCLUDE_PARENT` variable to your shell.

<details>
<summary>bash</summary>

Add the following line to `~/.bashrc`

```sh
export T_SESSION_NAME_INCLUDE_PARENT="true"
```

</details>

<details>
<summary>zsh</summary>

Add the following line to `~/.zshrc`

```sh
export T_SESSION_NAME_INCLUDE_PARENT="true"
```

</details>

<details>
<summary>fish</summary>

Add the following line to `~/.config/fish/conf.d/t.fish`

```fish
set -Ux T_SESSION_NAME_INCLUDE_PARENT true
```

</details>
