### PR TITLE
fix: fix syntax errors

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -113,7 +113,7 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
-		if [[ ! -v $FZF_TMUX_OPTS ]]; then
+		if [[ ! -n $FZF_TMUX_OPTS ]]; then
 			FZF_TMUX_OPTS="-p 53%,58%"
 		fi
 

--- a/bin/t
+++ b/bin/t
@@ -186,8 +186,7 @@ case $T_RUNTYPE in # attach to session
 attached)
 	tmux switch-client -t "$SESSION"
 	;;
-detached) ;&
-serverless)
+detached | serverless)
 	tmux attach -t "$SESSION"
 	;;
 esac


### PR DESCRIPTION
I was trying to upgrade the version of `t-smart-tmux-session-manager`, and then I got two syntax errors. 
**My computer info is:**
```
OS: macOS 13.5.2 22G91 arm64
Kernel: 22.6.0
Shell: fish 3.6.1
CPU: Apple M1
```

**The syntax errors are:**
-   **I got syntax error near `[if [[ ! -v $FZF_TMUX_OPTS ]]; then]`**
    - We could use the following two solutions
      - 1. `if [[ ! -n $FZF_TMUX_OPTS ]]; then`
      - 2. `if [ ! -v $FZF_TMUX_OPTS ]; then`
    - The differences between `-n` and `-v` are:
      
      | Option\\Value | non-empty | empty | not declared/not set |
      | ------------- | --------- | ----- | -------------------- |
      | -v            | true      | true  | false                |
      | -z            | false     | true  | true                 |
      | -n            | true      | false | false                |
   <img width="732" alt="Screenshot 2023-09-09 at 11 42 51" src="https://github.com/joshmedeski/t-smart-tmux-session-manager/assets/7600503/1e4bde88-90d8-401f-bb80-6f78692e0628">

- **I got another syntax error near `detached) ;&`**
<img width="668" alt="Screenshot 2023-09-09 at 11 44 02" src="https://github.com/joshmedeski/t-smart-tmux-session-manager/assets/7600503/07306190-c06f-4103-9f96-b9ea83bfffba">
