### PR TITLE
feat(binary): add zoxide bind to serverless mode

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -148,8 +148,9 @@ else # argument not provided
 			(zoxide query -l | sed -e "$HOME_REPLACER") | fzf \
 				--bind "$FIND_BIND" \
 				--bind "$TAB_BIND" \
+				--bind "$ZOXIDE_BIND" \
 				--border-label "$BORDER_LABEL" \
-				--header " ^f find" \
+				--header " ^x zoxide ^f find" \
 				--no-sort \
 				--prompt "$PROMPT"
 		)


### PR DESCRIPTION
Add the ^x zoxide bind even in serverless mode because once you use find bind you can no longer go back to zoxide listing.

resolves #57