### PR TITLE
add option to choose the initial results shown

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -98,6 +98,17 @@ get_sessions_by_mru() {
 	tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort --numeric-sort --reverse | awk '{print $2}'
 }
 
+# grab the @t-fzf-default-results global variable from tmux or set value to 'sessions zoxied' if none is provided
+get_results_from() {
+	local results_from
+  local default_results_from='zoxide sessions'
+	if [ "$TMUX_RUNNING" -eq 0 ]; then
+		results_from="$(tmux show -gqv '@t-fzf-default-results')"
+	fi
+	[ -n "$results_from" ] && echo "$results_from" || echo "$default_results_from"
+}
+RESULTS_FROM=$(get_results_from)
+
 if [ $# -eq 1 ]; then # argument provided
 	zoxide query "$1" &>/dev/null
 	ZOXIDE_RESULT_EXIT_CODE=$?
@@ -121,7 +132,13 @@ else # argument not provided
 		fi
 
 		RESULT=$(
-			(get_sessions_by_mru && (zoxide query -l | sed -e "$HOME_REPLACER")) | fzf-tmux \
+			(
+      # check if 'sessions' is provided in the @t-fzf-default-results variable
+      if [[ ${RESULTS_FROM[*]} =~ "sessions" ]]; then get_sessions_by_mru; fi \
+      && \
+      # check if 'zoxide' is provided in the @t-fzf-default-results variable
+      if [[ ${RESULTS_FROM[*]} =~ "zoxide" ]]; then (zoxide query -l | sed -e "$HOME_REPLACER"); fi \
+      ) | fzf-tmux \
 				--bind "$FIND_BIND" \
 				--bind "$SESSION_BIND" \
 				--bind "$TAB_BIND" \


### PR DESCRIPTION
In my personal workflow, I tend to have multiple sessions saved and restored with tmux-resurrect because I might be working on several projects in parallel.
Because of this, I tend to switch between projects very frequently, however, I don't tend to rely too much on zoxide, only when I open a brand new project or something along those lines.

That's why I was looking for a way to have an option set in `tmux.conf` to only show sessions when launched from within tmux, to actually limit my options, fuzzy find the session and not create a new session by mistake.

Add option as `@t-fzf-default-results` to allow to choose where the results come from when run inside tmux.
Default is the same as currently, returns results from zoxide and tmux sessions, but can be specified to be only zoxide, or only sessions.

I hope this is useful, and I'm happy to discuss this as much as necessary.

You are a great inspiration and this plugin is fantastic!!
I was previously using a very basic script and this feels like a massive upgrade regardless.