### PR TITLE
Convert tmux variables to shell variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,16 @@ To use the `t` script from anywhere, select your shell environment and follow th
 **Note:** you'll need to check the path of your tpm plugins. It may be `~/.tmux/plugins` or `~/.config/tmux/plugins` depending on where your `tmux.conf` is located.
 
 <details>
-<summary>bash</summary>
+<summary>zsh or bash</summary>
 
-Add the following line to `~/.bashrc`
+Add the following line to `~/.bashrc` for bash, and `~/.zprofile` for zsh.
 
 ```sh
 # ~/.tmux/plugins
 export PATH=$HOME/.tmux/plugins/t-smart-tmux-session-manager/bin:$PATH
-# ~/.config/tmux/plugins
-export PATH=$HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin:$PATH
 ```
 
-</details>
-
-<details>
-<summary>zsh</summary>
-
-Add the following line to `~/.zprofile`
-
 ```sh
-# ~/.tmux/plugins
-export PATH=$HOME/.tmux/plugins/t-smart-tmux-session-manager/bin:$PATH
 # ~/.config/tmux/plugins
 export PATH=$HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin:$PATH
 ```
@@ -75,11 +64,14 @@ export PATH=$HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin:$PATH
 <details>
 <summary>fish</summary>
 
-Add the following line to `~/.config/fish/config.fish`
+Add the following line to `~/.config/fish/conf.d/t.fish`
 
-```fish
+```sh
 # ~/.tmux/plugins
 fish_add_path $HOME/.tmux/plugins/t-smart-tmux-session-manager/bin
+```
+
+```sh
 # ~/.config/tmux/plugins
 fish_add_path $HOME/.config/tmux/plugins/t-smart-tmux-session-manager/bin
 ```
@@ -107,61 +99,36 @@ Or you can replace the prompt with anything you'd like.
 
 ## How to use
 
-```sh
-  Run interactive mode
-      t
-        ctrl-s list only tmux sessions
-        ctrl-x list only zoxide results
-        ctrl-f list results from the find command
-
-  Go to session (matches tmux session, zoxide result, or directory)
-      t {name}
-
-  Open popup (while in tmux)
-      <prefix>+T
-        ctrl-s list only tmux sessions
-        ctrl-x list only zoxide results
-        ctrl-f list results from the find command
-
-  Show help
-      t -h
-      t --help
-```
-
 By default, this plugin is bound to `<prefix>+T` which triggers a fzf-tmux popup that display zoxide results. Type the result you want and when you hit enter it will create a tmux session and connect to it or, if the sessions already exists, switch to it.
 
 If you are not in tmux, you can simply run `t` to start the interactive script, or call `t {name}` to jump directly to a session of your choosing.
 
-### Key Bindings
-
-- `ctrl-s` list only tmux sessions
-- `ctrl-x` list only zoxide results
-- `ctrl-f` find by directory
+You can run `t --help` or `t -h` to see the help menu.
 
 ## How to customize
 
-### Use Git Root for session name
+There are many ways you can customize this script to fit your workflow. I am also open to pull requests if you have ideas for improvements. Customizations are stored as shell variables, so they can be accessed with or without tmux running. Here are the available variables:
 
-You may prefer your session names starting from the root of the git repository. This can help with naming conflicts if you have multiple directories with the same name on your machine and make it clear when you have multiple sessions open in the same git repository.
-
-<details>
-<summary>bash</summary>
-
-Add the following line to `~/.bashrc`
-
-```sh
-export T_SESSION_USE_GIT_ROOT="true"
-```
-
-</details>
+- `T_FZF_FIND_BINDING`: overwrites the fzf `ctrl-f` key binding, typically used for finding a directory that's not listed in zoxide.
+- `T_FZF_PROMPT`: overwrites the fzf prompt symbol
+- `T_SESSION_USE_GIT_ROOT`: detects the git root of a chosen directory when generating a tmux sessions name
+- `T_SESSION_NAME_INCLUDE_PARENT`: includes the parent directory in the tmux session name
+- `T_FZF_BORDER_LABEL`: overwrites the fzf popup border label
+- `T_FZF_DEFAULT_RESULTS`: overwrites the default fzf results, can be "sessions" or "zoxide" (defaults to sessions and zoxide)
 
 <details>
-<summary>zsh</summary>
+<summary>zsh or bash</summary>
 
-Add the following line to `~/.zshrc`
+Add the following line to `~/.zshrc` for zsh, and `.bashrc` for bash.
 
 ```sh
-export T_SESSION_USE_GIT_ROOT="true"
+# use fd and search two levels deep from home
+export T_FZF_FIND_BINDING = 'ctrl-f:change-prompt(  )+reload(fd -H -d 2 -t d -E .Trash . ~)'
+export T_FZF_PROMPT = '🧠'
+export T_SESSION_USE_GIT_ROOT = true
+export T_SESSION_NAME_INCLUDE_PARENT = true # will fallback to parent if git root is not found
+export T_FZF_BORDER_LABEL = 'the ultimate tmux tool'
+export T_FZF_DEFAULT_RESULTS = 'sessions'
 ```
 
 </details>
@@ -172,47 +139,17 @@ export T_SESSION_USE_GIT_ROOT="true"
 Add the following line to `~/.config/fish/conf.d/t.fish`
 
 ```fish
+set -Ux T_FZF_FIND_BINDING 'ctrl-f:change-prompt(  )+reload(fd -H -d 2 -t d -E .Trash . ~)'
+set -Ux T_FZF_PROMPT '🧠'
 set -Ux T_SESSION_USE_GIT_ROOT true
-```
-
-</details>
-
-### Include parent dir in session name
-
-You may prefer your session names having a prefix of the parent directory. This can help with naming conflicts if you have multiple directories with the same name on your machine.
-
-<details>
-<summary>bash</summary>
-
-Add the following line to `~/.bashrc`
-
-```sh
-export T_SESSION_NAME_INCLUDE_PARENT="true"
-```
-
-</details>
-
-<details>
-<summary>zsh</summary>
-
-Add the following line to `~/.zshrc`
-
-```sh
-export T_SESSION_NAME_INCLUDE_PARENT="true"
-```
-
-</details>
-
-<details>
-<summary>fish</summary>
-
-Add the following line to `~/.config/fish/conf.d/t.fish`
-
-```fish
 set -Ux T_SESSION_NAME_INCLUDE_PARENT true
+set -Ux T_FZF_BORDER_LABEL 'the ultimate tmux tool'
+set -Ux T_FZF_DEFAULT_RESULTS 'sessions'
 ```
 
 </details>
+
+**Note:** `T_SESSION_USE_GIT_ROOT` and `T_SESSION_NAME_INCLUDE_PARENT` are in conflict right now, so I recommend choosing one or the other.
 
 ### Custom fzf-tmux keybinding
 

--- a/bin/t
+++ b/bin/t
@@ -65,27 +65,6 @@ if [ $HOME_SED_SAFE -eq 0 ]; then # $HOME should be safe to use in sed
 	HOME_REPLACER="s|^$HOME/|~/|"
 fi
 
-get_fzf_prompt() {
-	local fzf_prompt
-	local fzf_default_prompt='>  '
-	if [ "$TMUX_RUNNING" -eq 0 ]; then
-		fzf_prompt="$(tmux show -gqv '@t-fzf-prompt')"
-	fi
-	[ -n "$fzf_prompt" ] && echo "$fzf_prompt" || echo "$fzf_default_prompt"
-}
-PROMPT=$(get_fzf_prompt)
-
-get_fzf_find_binding() {
-	local fzf_find_binding
-	local fzf_find_binding_default='ctrl-f:change-prompt(find> )+reload(find ~ -maxdepth 3 -type d)'
-	if [ "$TMUX_RUNNING" -eq 0 ]; then
-		fzf_find_binding="$(tmux show -gqv '@t-fzf-find-binding')"
-	fi
-	[ -n "$fzf_find_binding" ] && echo "$fzf_find_binding" || echo "$fzf_find_binding_default"
-}
-
-FIND_BIND=$(get_fzf_find_binding)
-
 get_sessions_by_mru() {
 	tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort --numeric-sort --reverse | awk '{print $2}'
 }
@@ -113,12 +92,12 @@ get_fzf_results() {
 	fi
 }
 
-fzf_border_label_default=' t - smart tmux session manager '
-BORDER_LABEL=${T_FZF_BORDER_LABEL:-$fzf_border_label_default}
-
+BORDER_LABEL=${T_FZF_BORDER_LABEL:-' t - smart tmux session manager '}
+PROMPT=${T_FZF_PROMPT:-'>  '}
 HEADER=" ^s sessions ^x zoxide ^f find"
 SESSION_BIND="ctrl-s:change-prompt(sessions> )+reload(tmux list-sessions -F '#S')"
 ZOXIDE_BIND="ctrl-x:change-prompt(zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
+FIND_BIND=${T_FZF_FIND_BINDING:-'ctrl-f:change-prompt(find> )+reload(find ~ -maxdepth 3 -type d)'}
 TAB_BIND="tab:down,btab:up"
 
 if [ $# -eq 1 ]; then # argument provided

--- a/bin/t
+++ b/bin/t
@@ -28,32 +28,22 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
 	printf "\n"
 	printf "\033[32m  Run interactive mode\n"
 	printf "\033[34m      t\n"
-	printf "\033[34m        ctrl-s list only tmux sessions\n"
-	printf "\033[34m        ctrl-x list only zoxide results\n"
-	printf "\033[34m        ctrl-f list results from the find command\n"
+	printf "\033[34m        ctrl-s list tmux sessions\n"
+	printf "\033[34m        ctrl-x list zoxide entries\n"
+	printf "\033[34m        ctrl-f list find results\n"
 	printf "\n"
-	printf "\033[32m  Go to session (matches tmux session, zoxide result, or directory)\n"
+	printf "\033[32m  Go to session (matches tmux session, zoxide entry, or directory in pwd)\n"
 	printf "\033[34m      t {name}\n"
 	printf "\n"
 	printf "\033[32m  Open popup (while in tmux)\n"
-
-	if [ "$TMUX_RUNNING" -eq 0 ]; then
-		T_BIND=$(tmux show-option -gvq "@t-bind")
-		if [ "$T_BIND" = "" ]; then
-			T_BIND="T"
-		fi
-		printf "\033[34m      <prefix>+%s\n" "$T_BIND"
-		printf "\033[34m        ctrl-s list only tmux sessions\n"
-		printf "\033[34m        ctrl-x list only zoxide results\n"
-		printf "\033[34m        ctrl-f list results from the find command\n"
-	else
-		printf "\033[34m      start tmux server to see bindings\n" "$T_BIND"
-	fi
-
+	printf "\033[34m      <prefix>+%s\n" "${T_BIND:-T}"
+	printf "\033[34m        ctrl-s list tmux sessions\n"
+	printf "\033[34m        ctrl-x list zoxide entries\n"
+	printf "\033[34m        ctrl-f list find results\n"
 	printf "\n"
 	printf "\033[32m  Show help\n"
-	printf "\033[34m      t -h\n"
 	printf "\033[34m      t --help\n"
+	printf "\033[34m      t -h\n"
 	printf "\n"
 	exit 0
 fi

--- a/bin/t
+++ b/bin/t
@@ -65,8 +65,7 @@ get_zoxide_results() {
 
 get_fzf_results() {
 	if [ "$TMUX_RUNNING" -eq 0 ]; then
-		fzf_default_results="$(tmux show -gqv '@t-fzf-default-results')"
-		case $fzf_default_results in
+		case $T_FZF_DEFAULT_RESULTS in
 		sessions)
 			get_sessions_by_mru
 			;;

--- a/t-smart-tmux-session-manager.tmux
+++ b/t-smart-tmux-session-manager.tmux
@@ -1,14 +1,3 @@
 #!/usr/bin/env bash
-
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-tmux_option_or_fallback() {
-	local option_value
-	option_value="$(tmux show-option -gqv "$1")"
-	if [ -z "$option_value" ]; then
-		option_value="$2"
-	fi
-	echo "$option_value"
-}
-
-tmux bind-key "$(tmux_option_or_fallback "@t-bind" "T")" run-shell "$CURRENT_DIR/bin/t"
+tmux bind-key "$(${T_BIND:-'T'})" run-shell "$CURRENT_DIR/bin/t"


### PR DESCRIPTION
I originally started customizing this plugin using tmux variables which can't be read if tmux isn't running. So I switched to using shell variables (ex: [T_SESSION_NAME_INCLUDE_PARENT](https://github.com/joshmedeski/t-smart-tmux-session-manager/releases/tag/v2.2.0)) for some customizations in order to fix this issue.

This has left the user with two different places to customize the plugin (tmux variables or shell variables), which I think creates additional complexity for managing this plugin.

After some thought, I believe it's best to drop all tmux variables in favor of shell variables, here is my reasoning so that all customizations are in one place and work whether or not tmux is currently running.

I've also been able to simplify the README and show all configurations together, hopefully making it easier for people new to the shell and tmux to be able to approach customizing this shell to their needs more easily.

The added bonus is the bash code can use a fallback value inline during assignment, reducing the code significantly.

# 🚧 **BREAKING CHANGE** 🚧

The following tmux variables are dropped in favor of new shell variables.

- `@t-fzf-prompt` becomes `T_FZF_PROMPT`
- `@t-bind` becomes `T_BIND`
- `@t-fzf-default-results` becomes `T_DEFAULT_RESULTS`