### PR TITLE
Fix syntax errors in `t`

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -232,7 +232,7 @@ case $T_RUNTYPE in # attach to session
 attached)
 	tmux switch-client -t "$SESSION"
 	;;
-detached | serverless) # Both detached and serverless will execute the same command
+detached | serverless)
 	tmux attach -t "$SESSION"	
 ;;
 esac

--- a/bin/t
+++ b/bin/t
@@ -139,9 +139,9 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
-		if [[ ! -v $FZF_TMUX_OPTS ]]; then
-			FZF_TMUX_OPTS="-p 53%,58%"
-		fi
+    if [[ -z ${FZF_TMUX_OPTS} ]]; then
+      FZF_TMUX_OPTS="-p 53%,58%"
+    fi
 
 		RESULT=$(
 			(get_fzf_results) | fzf-tmux \
@@ -228,12 +228,11 @@ if [ "$SESSION" = "" ]; then # session is missing
 	fi
 fi
 
-case $T_RUNTYPE in # attach to session
-attached)
-	tmux switch-client -t "$SESSION"
-	;;
-detached) ;&
-serverless)
-	tmux attach -t "$SESSION"
-	;;
+case $T_RUNTYPE in
+  attached)
+    tmux switch-client -t "$SESSION"
+    ;;
+  detached | serverless) # Both detached and serverless will execute the same command
+    tmux attach -t "$SESSION"
+    ;;
 esac

--- a/bin/t
+++ b/bin/t
@@ -139,9 +139,9 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
-                if [[ -z ${FZF_TMUX_OPTS} ]]; then
-                  FZF_TMUX_OPTS="-p 53%,58%"
-                fi
+        	if [[ -z ${FZF_TMUX_OPTS} ]]; then
+        		FZF_TMUX_OPTS="-p 53%,58%"
+        	fi
 
 		RESULT=$(
 			(get_fzf_results) | fzf-tmux \
@@ -228,11 +228,11 @@ if [ "$SESSION" = "" ]; then # session is missing
 	fi
 fi
 
-case $T_RUNTYPE in
+case $T_RUNTYPE in # attach to session
 attached)
-        tmux switch-client -t "$SESSION"
-        ;;
+	tmux switch-client -t "$SESSION"
+	;;
 detached | serverless) # Both detached and serverless will execute the same command
-        tmux attach -t "$SESSION"
-        ;;
+	tmux attach -t "$SESSION"	
+;;
 esac

--- a/bin/t
+++ b/bin/t
@@ -139,9 +139,9 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
-    if [[ -z ${FZF_TMUX_OPTS} ]]; then
-      FZF_TMUX_OPTS="-p 53%,58%"
-    fi
+                if [[ -z ${FZF_TMUX_OPTS} ]]; then
+                  FZF_TMUX_OPTS="-p 53%,58%"
+                fi
 
 		RESULT=$(
 			(get_fzf_results) | fzf-tmux \
@@ -229,10 +229,10 @@ if [ "$SESSION" = "" ]; then # session is missing
 fi
 
 case $T_RUNTYPE in
-  attached)
-    tmux switch-client -t "$SESSION"
-    ;;
-  detached | serverless) # Both detached and serverless will execute the same command
-    tmux attach -t "$SESSION"
-    ;;
+attached)
+        tmux switch-client -t "$SESSION"
+        ;;
+detached | serverless) # Both detached and serverless will execute the same command
+        tmux attach -t "$SESSION"
+        ;;
 esac


### PR DESCRIPTION
Fixes the following syntax errors I was getting:
```
.../bin/t: line 142: conditional binary operator expected
.../bin/t: line 142: syntax error near `$FZF_TMUX_OPTS'
.../bin/t: line 142: `      if [[ ! -v $FZF_TMUX_OPTS ]]; then'
```
and
```
.../bin/t: line 235: syntax error near unexpected token `;'
.../bin/t: line 235: `  detached) ;&'
```