### PR TITLE
feat: add `git worktree` support

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -208,7 +208,7 @@ elif [[ $T_SESSION_USE_GIT_ROOT == 'true' ]]; then
 
 		# git worktree
 		GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir 2>/dev/null) && echo $GIT_WORKTREE_ROOT >/dev/null
-		if [[ $? -eq 0 ]] && [[ ! $GIT_WORKTREE_ROOT =~ ^(\.\./)+\.git$ ]]; then # is inside git worktree
+		if [[ $? -eq 0 ]] && [[ ! $GIT_WORKTREE_ROOT =~ ^(\.\./)*\.git$ ]]; then # is inside git worktree
 			GIT_WORKTREE_ROOT=$(echo $GIT_WORKTREE_ROOT | sed -E 's/(\/.git|\/.bare)$//') # remove .git or .bare suffix
 			BASENAME=$(basename $GIT_WORKTREE_ROOT)
 			RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}

--- a/bin/t
+++ b/bin/t
@@ -207,8 +207,9 @@ elif [[ $T_SESSION_USE_GIT_ROOT == 'true' ]]; then
 		RELATIVE_PATH=${RESULT#$GIT_ROOT}
 
 		# git worktree
-		if [ "$(git -C $RESULT rev-parse --is-inside-work-tree)" == "true" ] && [ -f "$RESULT/.git" ]; then # is inside git worktree
-			GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir | sed 's/\/.bare$//' 2>/dev/null)
+		GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir 2>/dev/null) && echo $GIT_WORKTREE_ROOT >/dev/null
+		if [[ $? -eq 0 ]] && [[ ! $GIT_WORKTREE_ROOT =~ ^(\.\./)+\.git$ ]]; then # is inside git worktree
+			GIT_WORKTREE_ROOT=$(echo $GIT_WORKTREE_ROOT | sed -E 's/(\/.git|\/.bare)$//') # remove .git or .bare suffix
 			BASENAME=$(basename $GIT_WORKTREE_ROOT)
 			RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}
 		fi

--- a/bin/t
+++ b/bin/t
@@ -203,8 +203,16 @@ elif [[ $T_SESSION_USE_GIT_ROOT == 'true' ]]; then
 	if [[ $? -ne 0 ]]; then # not inside git repository
 		SESSION_NAME=$(basename "$RESULT" | tr ' .:' '_')
 	else # is in git repository
-		BASENAME=$(basename $GIT_ROOT)
-		RELATIVE_PATH=${RESULT#$GIT_ROOT}
+    BASENAME=$(basename $GIT_ROOT)
+    RELATIVE_PATH=${RESULT#$GIT_ROOT}
+
+    # git worktree
+    if [ "$(git -C $RESULT rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then # is inside git worktree
+      GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir | sed 's/\/.bare$//' 2>/dev/null)
+      BASENAME=$(basename $GIT_WORKTREE_ROOT)
+      RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}
+    fi
+
 		SEPARATOR="/"
 		FORMATTED_PATH="${RELATIVE_PATH//\//$SEPARATOR}"
 		SESSION_NAME=$(echo $BASENAME$FORMATTED_PATH | tr ' .:' '_')

--- a/bin/t
+++ b/bin/t
@@ -203,15 +203,15 @@ elif [[ $T_SESSION_USE_GIT_ROOT == 'true' ]]; then
 	if [[ $? -ne 0 ]]; then # not inside git repository
 		SESSION_NAME=$(basename "$RESULT" | tr ' .:' '_')
 	else # is in git repository
-    BASENAME=$(basename $GIT_ROOT)
-    RELATIVE_PATH=${RESULT#$GIT_ROOT}
+		BASENAME=$(basename $GIT_ROOT)
+		RELATIVE_PATH=${RESULT#$GIT_ROOT}
 
-    # git worktree
-    if [ "$(git -C $RESULT rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then # is inside git worktree
-      GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir | sed 's/\/.bare$//' 2>/dev/null)
-      BASENAME=$(basename $GIT_WORKTREE_ROOT)
-      RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}
-    fi
+		# git worktree
+		if [ "$(git -C $RESULT rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then # is inside git worktree
+			GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir | sed 's/\/.bare$//' 2>/dev/null)
+			BASENAME=$(basename $GIT_WORKTREE_ROOT)
+			RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}
+		fi
 
 		SEPARATOR="/"
 		FORMATTED_PATH="${RELATIVE_PATH//\//$SEPARATOR}"

--- a/bin/t
+++ b/bin/t
@@ -207,7 +207,7 @@ elif [[ $T_SESSION_USE_GIT_ROOT == 'true' ]]; then
 		RELATIVE_PATH=${RESULT#$GIT_ROOT}
 
 		# git worktree
-		if [ "$(git -C $RESULT rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then # is inside git worktree
+		if [ "$(git -C $RESULT rev-parse --is-inside-work-tree)" == "true" ] && [ -f "$RESULT/.git" ]; then # is inside git worktree
 			GIT_WORKTREE_ROOT=$(git -C $RESULT rev-parse --git-common-dir | sed 's/\/.bare$//' 2>/dev/null)
 			BASENAME=$(basename $GIT_WORKTREE_ROOT)
 			RELATIVE_PATH=${RESULT#$GIT_WORKTREE_ROOT}


### PR DESCRIPTION
- **Issue**: The tmux session_name will be displayed as the name `main` if I'm using `git worktree` to manage my git project. 
- **Solution**: Add the project name to the session_name. 
  - **before**:
      - `main`
      -  `add-xxx-support`
  - **after**:
    - `infra/main`
    -  `infra/add-xxx-support`


--- 
<img width="1902" alt="image" src="https://github.com/joshmedeski/t-smart-tmux-session-manager/assets/7600503/80bc5831-3b8c-46c3-88c1-d9b731205b29">
<img width="988" alt="image" src="https://github.com/joshmedeski/t-smart-tmux-session-manager/assets/7600503/691dde18-44bc-47ee-92d6-055a821916bd">

