### PR TITLE
Downgrade bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,11 @@ tmux is a powerful tool, but dealing with sessions can be painful. This script m
 
 - [tmux](https://github.com/tmux/tmux) (>= 3.2)
 - [tpm](https://github.com/tmux-plugins/tpm)
-- [bash](https://www.gnu.org/software/bash/) (>= 4.0)
 - [zoxide](https://github.com/ajeetdsouza/zoxide)
 - [fzf](https://github.com/junegunn/fzf) (>=0.35.0)
 
-**Note:** Macs have bash v3 preinstalled, you'll need v4 or later for this script. I recommend installing these prerequisites from homebrew to get the latest versions.
-
 ```
-brew install tmux bash zoxide fzf
+brew install tmux zoxide fzf
 ```
 
 Use the package manager of your OS if you are not on macOS.

--- a/bin/t
+++ b/bin/t
@@ -139,7 +139,7 @@ if [ $# -eq 1 ]; then # argument provided
 else # argument not provided
 	case $T_RUNTYPE in
 	attached)
-		if [[ ! -v $FZF_TMUX_OPTS ]]; then
+		if [[ -z $FZF_TMUX_OPTS ]]; then
 			FZF_TMUX_OPTS="-p 53%,58%"
 		fi
 

--- a/bin/t
+++ b/bin/t
@@ -232,8 +232,7 @@ case $T_RUNTYPE in # attach to session
 attached)
 	tmux switch-client -t "$SESSION"
 	;;
-detached) ;&
-serverless)
+detached | serverless)
 	tmux attach -t "$SESSION"
 	;;
 esac


### PR DESCRIPTION
I've gotten half a dozen or more issues related to people not upgrading to bash >= 4. I was able to convert the bash script to  be compatible with version 3, which is what most macs ship with. Hopefully this reduces issues!