### PR TITLE
feat: add an option to pass in a command to session before opening

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -21,7 +21,7 @@ if [ "$TMUX_RUNNING" -eq 0 ]; then
 fi
 
 # display help text with an argument
-if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
+function display_help() {
 	printf "\n"
 	printf "\033[1m  t - the smart tmux session manager\033[0m\n"
 	printf "\033[37m  https://github.com/joshmedeski/t-smart-tmux-session-manager\n"
@@ -51,12 +51,17 @@ if [ "$1" = "-h" ] || [ "$1" == "--help" ]; then
 	fi
 
 	printf "\n"
+	printf "\033[32m  Send a command to session before opening\n"
+	printf "\033[34m      t -c [COMMAND]\n"
+	printf "\033[34m      t --command [COMMAND]\n"
+	printf "\033[34m      t [QUERY] -c [COMMAND]\n"
+	printf "\033[34m      t [QUERY] --command [COMMAND]\n"
+	printf "\n"
 	printf "\033[32m  Show help\n"
 	printf "\033[34m      t -h\n"
 	printf "\033[34m      t --help\n"
 	printf "\n"
-	exit 0
-fi
+}
 
 HOME_REPLACER=""                                          # default to a noop
 echo "$HOME" | grep -E "^[a-zA-Z0-9\-_/.@]+$" &>/dev/null # chars safe to use in sed
@@ -113,6 +118,73 @@ get_fzf_results() {
 	fi
 }
 
+function fzf_finder() {
+  case $T_RUNTYPE in
+    attached)
+      if [[ -z $FZF_TMUX_OPTS ]]; then
+        FZF_TMUX_OPTS="-p 53%,58%"
+      fi
+
+      RESULT=$(
+      (get_fzf_results) | fzf-tmux \
+        --bind "$FIND_BIND" \
+        --bind "$SESSION_BIND" \
+        --bind "$TAB_BIND" \
+        --bind "$ZOXIDE_BIND" \
+        --border-label "$BORDER_LABEL" \
+        --header "$HEADER" \
+        --no-sort \
+        --prompt "$PROMPT" \
+        $FZF_TMUX_OPTS
+      )
+      ;;
+    detached)
+      RESULT=$(
+      (get_fzf_results) | fzf \
+        --bind "$FIND_BIND" \
+        --bind "$SESSION_BIND" \
+        --bind "$TAB_BIND" \
+        --bind "$ZOXIDE_BIND" \
+        --border \
+        --border-label "$BORDER_LABEL" \
+        --header "$HEADER" \
+        --no-sort \
+        --prompt "$PROMPT"
+      )
+      ;;
+    serverless)
+      RESULT=$(
+      (get_fzf_results) | fzf \
+        --bind "$FIND_BIND" \
+        --bind "$TAB_BIND" \
+        --bind "$ZOXIDE_BIND" \
+        --border \
+        --border-label "$BORDER_LABEL" \
+        --header " ^x zoxide ^f find" \
+        --no-sort \
+        --prompt "$PROMPT"
+      )
+      ;;
+  esac
+}
+
+function query_zoxide_from_argument() {
+  zoxide query "$1" &>/dev/null
+  ZOXIDE_RESULT_EXIT_CODE=$?
+  if [ $ZOXIDE_RESULT_EXIT_CODE -eq 0 ]; then # zoxide result found
+    RESULT=$(zoxide query "$1")
+  else # no zoxide result found
+    ls "$1" &>/dev/null
+    LS_EXIT_CODE=$?
+    if [ $LS_EXIT_CODE -eq 0 ]; then # directory found
+      RESULT=$1
+    else # no directory found
+      echo "No directory found."
+      exit 1
+    fi
+  fi
+}
+
 fzf_border_label_default=' t - smart tmux session manager '
 BORDER_LABEL=${T_FZF_BORDER_LABEL:-$fzf_border_label_default}
 
@@ -121,69 +193,38 @@ SESSION_BIND="ctrl-s:change-prompt(sessions> )+reload(tmux list-sessions -F '#S'
 ZOXIDE_BIND="ctrl-x:change-prompt(zoxide> )+reload(zoxide query -l | sed -e \"$HOME_REPLACER\")"
 TAB_BIND="tab:down,btab:up"
 
-if [ $# -eq 1 ]; then # argument provided
-	zoxide query "$1" &>/dev/null
-	ZOXIDE_RESULT_EXIT_CODE=$?
-	if [ $ZOXIDE_RESULT_EXIT_CODE -eq 0 ]; then # zoxide result found
-		RESULT=$(zoxide query "$1")
-	else # no zoxide result found
-		ls "$1" &>/dev/null
-		LS_EXIT_CODE=$?
-		if [ $LS_EXIT_CODE -eq 0 ]; then # directory found
-			RESULT=$1
-		else # no directory found
-			echo "No directory found."
-			exit 1
-		fi
-	fi
-else # argument not provided
-	case $T_RUNTYPE in
-	attached)
-		if [[ -z $FZF_TMUX_OPTS ]]; then
-			FZF_TMUX_OPTS="-p 53%,58%"
-		fi
+QUERY_PROVIDED=false
+while [ "$#" -gt 0 ]; do # process arguments
+  case "$1" in
+    -h|--help)
+      display_help
 
-		RESULT=$(
-			(get_fzf_results) | fzf-tmux \
-				--bind "$FIND_BIND" \
-				--bind "$SESSION_BIND" \
-				--bind "$TAB_BIND" \
-				--bind "$ZOXIDE_BIND" \
-				--border-label "$BORDER_LABEL" \
-				--header "$HEADER" \
-				--no-sort \
-				--prompt "$PROMPT" \
-				$FZF_TMUX_OPTS
-		)
-		;;
-	detached)
-		RESULT=$(
-			(get_fzf_results) | fzf \
-				--bind "$FIND_BIND" \
-				--bind "$SESSION_BIND" \
-				--bind "$TAB_BIND" \
-				--bind "$ZOXIDE_BIND" \
-				--border \
-				--border-label "$BORDER_LABEL" \
-				--header "$HEADER" \
-				--no-sort \
-				--prompt "$PROMPT"
-		)
-		;;
-	serverless)
-		RESULT=$(
-			(get_fzf_results) | fzf \
-				--bind "$FIND_BIND" \
-				--bind "$TAB_BIND" \
-				--bind "$ZOXIDE_BIND" \
-				--border \
-				--border-label "$BORDER_LABEL" \
-				--header " ^x zoxide ^f find" \
-				--no-sort \
-				--prompt "$PROMPT"
-		)
-		;;
-	esac
+      shift # pop off argument
+      exit 0
+      ;;
+    -c|--command)
+      COMMAND="$2"
+
+      # pop off argument and value
+      shift
+      shift
+      ;;
+    *) # pass in query into zoxide
+      if [ "$#" -eq 2 ]; then
+        echo "Invalid argument: $1"
+        exit 1
+      fi
+
+      QUERY_PROVIDED=true
+      query_zoxide_from_argument "$1"
+
+      shift # pop off argument
+      ;;
+  esac
+done
+
+if [ "$QUERY_PROVIDED" = false ]; then # fuzzy find zoxide results
+  fzf_finder
 fi
 
 if [ "$RESULT" = "" ]; then # no result
@@ -226,6 +267,12 @@ if [ "$SESSION" = "" ]; then # session is missing
 	else
 		tmux new-session -d -s "$SESSION" -c "$RESULT" # create session
 	fi
+fi
+
+if [ "$COMMAND" != "" ]; then # send command to session
+  WINDOW_INFO=$(tmux list-windows -t "$SESSION" | grep '(active)')
+  SESSION_ACTIVE_WINDOW=$(echo "$WINDOW_INFO" | awk '{print $1}' | sed 's/://')
+  tmux send-keys -t "$SESSION:$SESSION_ACTIVE_WINDOW" "$COMMAND" Enter
 fi
 
 case $T_RUNTYPE in # attach to session


### PR DESCRIPTION
I thought this option would be useful since it's portable if you want to execute a one-off command or integrate `t` into a script. You can still utilize `.t` scripts along with the command argument. For example, say you have some projects that contain this `.t` script:
```
#!/usr/bin/env bash
tmux new-window
npm run dev
tmux select-window -t 0
nvim .
```
You might want to run a script to open a couple of these projects, pull the latest code, and create docker-compose files (idk random scenario), while still having your `.t` scripts being executed. You can accomplish that by doing this (in fish shell):
```
for project in project1 project2 project3
    t $project --command "git pull && touch docker-compose.yml" --priority 0 # (default -> runs the command before .t)
end
```
You can use -c or --command and -p or --priority with values 0 (default) or 1 to determine if the command or the `.t` script gets executed first (if a `.t` script exists). The only caveat is that if you include a command argument to open an interactive program like neovim or less, then exiting that program will not automatically close the window, unlike before. But, if you run `t` without a command argument, it will behave the same as before.