### PR TITLE
feat: add --recursive to "git clone"

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -135,7 +135,7 @@ if [ $# -ge 1 ]; then # argument provided
 				exit 1
 			fi
 			cd $T_REPOS_DIR
-			git clone $REPO_URL
+			git clone --recursive $REPO_URL
 			RESULT="$T_REPOS_DIR/$REPO"
 		else
 			echo "Invalid GitHub repository URL"


### PR DESCRIPTION
## Why this change?

Sometimes there are (unfortunately) git submodules in the projects I clone down. Would be nice if `t --repos` would just clone down all of those by default.

### What was changed?

Low-effort contribution where I just added `--recursive` to be the default to the `git clone` command. 😄

### Notes

I was first thinking of forwarding any arguments onto `git clone`, so I could just run `t --repos --recursive <url>` myself. But then I see you are already mucking around quite a lot with arguments so I didn't want to go down that route, just to keep this simple.

But in case you want to explore the ability to forward args to `git clone`, it might be possible to shift past the `-r`/`--repos` args:

```bash
#!/bin/bash

# Define function for the 'directory' command
directory_cmd() {
    echo "Running directory command with arguments: $@"
    # this is where you'd invoke the regular implementation for `t <directory>`
}

# Define function for the 'repos' command
repos_cmd() {
    echo "Running repos command with arguments: $@"
    # this is where you'd run `cd $T_REPOS_DIR && git clone $@`
}

# Main command logic
case "$1" in
    -r|--repos)
        # Remove the first argument (-r or --repos) and call repos_cmd with the rest
        shift
        repos_cmd "$@"
        ;;
    *)
        # Default case (no command given): call directory_cmd with all arguments
        directory_cmd "$@"
        ;;
esac

```