### PR TITLE
fix: exclude current session from session list

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -87,7 +87,15 @@ get_fzf_find_binding() {
 FIND_BIND=$(get_fzf_find_binding)
 
 get_sessions_by_mru() {
-	tmux list-sessions -F '#{session_last_attached} #{session_name}' | sort --numeric-sort --reverse | awk '{print $2}'
+	if [ "$T_RUNTYPE" == "attached" ]; then
+		CURRENT_SID=$(tmux display-message -p "#{session_id}")
+	else
+		CURRENT_SID=""
+	fi
+	tmux list-sessions \
+		-f "#{!=:#{session_id},$CURRENT_SID}" \
+		-F '#{session_last_attached} #{session_name}' \
+		| sort --numeric-sort --reverse | awk '{print $2}'
 }
 
 get_zoxide_results() {


### PR DESCRIPTION
I find myself usually use t keybinding and then enter to switch to alternative session (same result could be achieved with prefix + L).
Default behavior list current session in the session list make no sense because I don't want to jump to current session. 
I notice `tmux list-sessions` command also have `--filter` argument so I try to filter out current session with session unique ID.

Please let me know if I could write better script cause I'm not good with scripting.

Thanks for amazing tmux plugins.