### PR TITLE
Add separator line

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -95,7 +95,7 @@ get_sessions_by_mru() {
 	tmux list-sessions \
 		-f "#{!=:#{session_id},$CURRENT_SID}" \
 		-F '#{session_last_attached} #{session_name}' \
-		| sort --numeric-sort --reverse | awk '{print $2}'
+		| sort --numeric-sort --reverse | awk '{print $2}; END {print "———"}'
 }
 
 get_zoxide_results() {


### PR DESCRIPTION
Hi Josh,

still enjoying the t session manager a lot (looking forward to the rewrite in Go), but here's something that has been bugging me for a while.

Sometimes I get confused by the fact that my **active tmux sessions are listed together with the rest of the options** (zoxide etc.) to choose from. I've added a small horizontal separator line and for me this is a really helpful detail.

Perhaps you'd like to merge this? Not sure if it's 100% the correct way to do this, also wondering whether all terminals will render the hardcoded UTF-8 em dash correctly, but it's so much prettier than the ASCII single dash `- `!

All the best,

Tom.

![image](https://github.com/joshmedeski/t-smart-tmux-session-manager/assets/37420199/79eb6f26-c082-43e8-b472-abca63698833)
