### PR TITLE
feat: make `.git` in repo url optional

### DIFF
--- a/bin/t
+++ b/bin/t
@@ -136,7 +136,7 @@ if [ $# -ge 1 ]; then # argument provided
 			exit 1
 		fi
 		REPO_URL=$2
-		if [[ $REPO_URL =~ \/([^\/]+)\.git$ ]]; then
+		if [[ $REPO_URL =~ \/([^\/]+)\(.git)?$ ]]; then
 			REPO="${BASH_REMATCH[1]}"
 			if [[ -z $T_REPOS_DIR ]]; then
 				echo "T_REPOS_DIR has not been set"

--- a/bin/t
+++ b/bin/t
@@ -136,7 +136,7 @@ if [ $# -ge 1 ]; then # argument provided
 			exit 1
 		fi
 		REPO_URL=$2
-		if [[ $REPO_URL =~ \/([^\/]+)\(.git)?$ ]]; then
+		if [[ $REPO_URL =~ \/([^\/]+)(\.git)?$ ]]; then
 			REPO="${BASH_REMATCH[1]}"
 			if [[ -z $T_REPOS_DIR ]]; then
 				echo "T_REPOS_DIR has not been set"


### PR DESCRIPTION
I like to copy URL directly from the omnibox of browser reference: #100

Very small PR, but this really hinders my workflow. If merged I wouldn't have to manage my own fork :)